### PR TITLE
Add second processor support to wget.asm

### DIFF
--- a/rom/wget.asm
+++ b/rom/wget.asm
@@ -361,7 +361,7 @@
  bne wget_check_flags       \ if not zero then continue 
 .wget_reread_ipd
  jsr wget_search_ipd        \ else search next IPD string
- bcs .wget_reread_ipd2
+ bcs wget_reread_ipd2
  jmp wget_crd_end           \ end if no IPD string found 
 .wget_reread_ipd2
  jsr wget_read_ipd          \ read IPD (= number of bytes in datablok)

--- a/rom/wget.asm
+++ b/rom/wget.asm
@@ -6,7 +6,7 @@
 \            -P        optional    the file has an Atom-in-PC header
 \            -U        optional    the file is a UEF file
 \            -S        optional    the file is a sideways rom, specify banknumber in address parameter
-             -F        optional    force file to load in host if second processor present
+\             -F        optional    force file to load in host if second processor present
 \            url       required    the url of the file, including http(s)://
 \            address   optional    load address of the file
 \ The address will override the load address in the ATM header (if any). It will be ignored with the -T parameters since that option

--- a/rom/wget.asm
+++ b/rom/wget.asm
@@ -6,7 +6,7 @@
 \            -P        optional    the file has an Atom-in-PC header
 \            -U        optional    the file is a UEF file
 \            -S        optional    the file is a sideways rom, specify banknumber in address parameter
-\             -F        optional    force file to load in host if second processor present
+\            -F        optional    force file to load in host if second processor present
 \            url       required    the url of the file, including http(s)://
 \            address   optional    load address of the file
 \ The address will override the load address in the ATM header (if any). It will be ignored with the -T parameters since that option

--- a/rom/wget.asm
+++ b/rom/wget.asm
@@ -361,7 +361,9 @@
  bne wget_check_flags       \ if not zero then continue 
 .wget_reread_ipd
  jsr wget_search_ipd        \ else search next IPD string
- bcc wget_crd_end           \ end if no IPD string found 
+ bcs .wget_reread_ipd2
+ jmp wget_crd_end           \ end if no IPD string found 
+.wget_reread_ipd2
  jsr wget_read_ipd          \ read IPD (= number of bytes in datablok)
  jsr wget_search_crlf       \ search end of response headers
 

--- a/rom/wget.asm
+++ b/rom/wget.asm
@@ -329,7 +329,8 @@
  lda laddr                  \ get load address and initiate tube here to avoid loss of data while tube starts
  ora laddr+1
  bne wget_claim_tube        \ yes, there is a load address so jump
- jsr wget_set_default_load  \ otherwise set the default load address
+ lda #8                     \ default to PAGE (&800 in second processor)
+ sta laddr+1
 .wget_claim_tube
  lda #&FF                   \ claim tube interface
  jsr &406
@@ -772,13 +773,8 @@ if __ELECTRON__
  pha
  tya
  pha
- ldx #0
- ldy #8
- bit fflag                  \ PAGE is &800 on second processor
- bmi tube_address
  lda #&83                   \ perform OSBYTE &83: return current OSHWM
  jsr osbyte
- .tube_address
  stx laddr                  \ save low byte
  sty laddr+1                \ save high byte
  pla                        \ restore x and y registers


### PR DESCRIPTION
Add support for second processor.
If present data transfers will go to the second processor unless flags are set. The load address will default to PAGE (&800) unless supplied.
A new flag F will force loading into the host processor. Any other flags will do the same.
If the load address is >= &8000 it is a ROM and a run command will be sent to the second processor. Care must be taken that the correct load address is supplied, ie. usually 8000 or B800. If it is wrong the system will probably crash!